### PR TITLE
Add deprecation notice

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -3,7 +3,7 @@ Contributors to the SYCL Parallel STL project
 
 By order of appearance in the commit log:
 
-* Ruyman Reyes, ruyman@codeplay.com
+* Ruyman Reyes
 * Jeremy Wright, jeremy@quiescent.us
 * Andrew Richards, andrew@codeplay.com
 * Antonio Vilches, vilches@uma.es

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ SYCL Parallel STL [![Build Status](https://travis-ci.org/KhronosGroup/SyclParall
 This project features an implementation of the Parallel STL library
 using the Khronos SYCL standard.
 
+**The project is not actively developed anymore and is outdated. It has been
+archived to preserve history, but is deprecated and should not be used
+anymore!**
+
 What is Parallel STL
 -----------------------
 


### PR DESCRIPTION
The project is not developed anymore and outdated. Unsuspecting users should be warned about this.